### PR TITLE
feat: less flickering when searching in cmdline

### DIFF
--- a/lua/ui/cmdline.lua
+++ b/lua/ui/cmdline.lua
@@ -414,12 +414,11 @@ cmdline.__render = function ()
 		---|fE
 	end
 
-	if vim.list_contains({ "/", "?" }, cmdline.state.firstc) or string.match(lines[#lines], "^%s*[%S]*s/") then
+	if string.match(lines[#lines], "^%s*[%S]*s/") then
 		-- When we do `:s/`(aka substitute) Neovim will
 		-- schedule the screen updates *after* the preview.
 		--
 		-- So, we update the screen immediately.
-		-- Same when searching.
 		render_callback();
 	else
 		vim.schedule(render_callback);


### PR DESCRIPTION
When `blink.nvim` cmdline completion is enabled, some flickering happens when searching for a word.

Using `vim.shedule(render_callback)` instead of `render_callback()` fixes it.

I tested this change on a minimal env where only `ui.nvim` is loaded and didn't see any regression.