### PR TITLE
feat(history): always show history at the bottom

### DIFF
--- a/lua/ui/message.lua
+++ b/lua/ui/message.lua
@@ -878,6 +878,7 @@ message.__history = function (entries)
 
 	local window_config = vim.tbl_extend("force", {
 		split = "below",
+		win = -1, -- creates top-level split
 		height = 10,
 
 		hide = false


### PR DESCRIPTION
# issue
When navigating in an upper horizontal splits, `:messages` will show below current window, but not at the bottom of the screen:

Before:
```
-------------
current
-------------
below
-------------
```

After:
```
-------------
current
-------------
history
-------------
below
-------------
```

# solution
Use `win = -1` when calling `nvim_open_win()` to make the split "top-level".

After:
```
-------------
current
-------------
below
-------------
history
-------------
```

Note that we can already achieve this today the `message.history_winconfig` setting, but I thought it would make sense to make this the default behavior.

What do you think?