### PR TITLE
fix: open windows from nvim command (-o/-O/-p)

### DIFF
--- a/lua/ui/cmdline.lua
+++ b/lua/ui/cmdline.lua
@@ -618,10 +618,14 @@ cmdline.setup = function ()
 		end
 	});
 
-	log.assert(
-		"ui/cmdline.lua",
-		pcall(cmdline.__prepare)
-	);
+	vim.api.nvim_create_autocmd("VimEnter", {
+		callback = function ()
+			log.assert(
+				"ui/cmdline.lua",
+				pcall(cmdline.__prepare)
+			);
+		end
+	});
 
 	---|fE
 end

--- a/lua/ui/message.lua
+++ b/lua/ui/message.lua
@@ -1112,7 +1112,11 @@ end
 message.setup = function ()
 	---|fS
 
-	message.__prepare();
+	vim.api.nvim_create_autocmd("VimEnter", {
+		callback = function ()
+			message.__prepare();
+		end
+	});
 
 	vim.api.nvim_create_autocmd("VimResized", {
 		callback = function ()

--- a/lua/ui/popup.lua
+++ b/lua/ui/popup.lua
@@ -501,7 +501,11 @@ popup.setup = function ()
 		end
 	});
 
-	popup.__prepare();
+	vim.api.nvim_create_autocmd("VimEnter", {
+		callback = function ()
+			popup.__prepare();
+		end
+	});
 
 	---|fE
 end


### PR DESCRIPTION
# ℹ issue
`nvim` `-o` `-O` and `-p` options are currently misbehaving. The `__prepare()` windows are used instead of the normal split windows/tabs that those options are meant to create.

# 👶 minimal reproduction
```bash
# in ui.nvim repo:
nvim --clean -u init.lua README.md CHANGELOG.md -o
```

Where `init.lua` is:
```lua
vim.opt.rtp:prepend("$PWD")
```

# 🔜 fix
User `VimEnter` autocmd to call initial `__prepare()` functions.