### PR TITLE
fix(message): list message reappears on resize

### DIFF
--- a/lua/ui/message.lua
+++ b/lua/ui/message.lua
@@ -1167,6 +1167,16 @@ message.setup = function ()
 		end
 	});
 
+	vim.api.nvim_create_autocmd("WinClosed", {
+		callback = function ()
+			local tab = vim.api.nvim_get_current_tabpage()
+			if message.list_window[tab] == vim.api.nvim_get_current_win() then
+				message.list_window[tab] = nil;
+				vim.g.__ui_list_msg = nil;
+			end
+		end
+	})
+
 	vim.api.nvim_create_autocmd("VimResized", {
 		callback = function ()
 			if vim.g.__ui_confirm_msg then


### PR DESCRIPTION
# repro

1. `:highlight`
2. `:q`
3. resize

It was only working fine when pressing `q` thanks to the callback.

# questions

Why do we want to hide the list_window instead of closing it in the first place?

I don't understand why we allocate and hide so many windows in the 1st place (I might be missing something here)?

It seems to be adding a lot of complexity and corner cases in the code.