### PR TITLE
feat: implement vim.notify

### DIFF
--- a/lua/definitions/spec.lua
+++ b/lua/definitions/spec.lua
@@ -46,6 +46,7 @@
 ---@class ui.config.message
 ---
 ---@field enable? boolean Should this module be enabled?
+---@field notify? boolean Override `vim.notify` with ui.nvim messages (no replace)?
 ---@field respect_replace_last? boolean Should `replace_last` be respected?
 ---
 ---@field history_preference? "vim" | "ui" History preference for :messages

--- a/lua/ui/message.lua
+++ b/lua/ui/message.lua
@@ -1274,6 +1274,28 @@ end
 message.setup = function ()
 	---|fS
 
+	if spec.config.message.notify == true then
+		function vim.notify(msg, level, opts)
+			if level == vim.log.levels.OFF then
+				return;
+			end
+
+			if opts and opts.title then
+				msg = string.format("%s\n%s", opts.title, msg)
+			end
+
+			local hl
+			if level == vim.log.levels.ERROR then
+				hl = 'ErrorMsg'
+			elseif level == vim.log.levels.WARN then
+				hl = 'WarningMsg'
+			else
+				hl = 'Normal'
+			end
+			message.msg_show("", { {0, msg, vim.fn.hlID(hl)} }, false, true);
+		end
+	end
+
 	vim.api.nvim_create_autocmd("VimResized", {
 		callback = function ()
 			message.__list_resize();

--- a/lua/ui/spec.lua
+++ b/lua/ui/spec.lua
@@ -589,6 +589,7 @@ spec.default = {
 		---|fS
 
 		enable = true,
+		notify = true,
 		respect_replace_last = true,
 
 		history_preference = "vim",


### PR DESCRIPTION
Implement `vim.notify ` to use simple pre-existing `ui.nvim` messages.

It calls `msg_show()` with `replace_last = false`, I believe this is expected implementation.  
That way we don't have to set `respect_replace_last = false` globally. See #28 